### PR TITLE
fix: update readme heading

### DIFF
--- a/catalog/.codemodrc.json
+++ b/catalog/.codemodrc.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
 	"name": "pnpm/catalog",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"engine": "workflow",
 	"private": false,
 	"arguments": [],

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,4 +1,4 @@
-# Migrate to [pnpm catalog](https://pnpm.io/catalogs)
+This codemod helps you migrate to [pnpm catalog](https://pnpm.io/catalogs):
 
 * Performs search across all packages in pnpm workspace.
 * If there are more than 2 packages with same dependency - it will move dependency to catalog.


### PR DESCRIPTION
[Codemod Registry](https://codemod.com/registry) already prints out the codemod h1 title using the codemod name. This PR changes the first line from a heading to a paragraph to fix this issue.

<img width="856" alt="Screenshot 2024-07-11 at 6 20 56 PM" src="https://github.com/pnpm/codemod/assets/37941642/26801128-fd11-4d10-85f5-1255106326e2">
