### PR TITLE
fix: resolve CODEMOD_PATH inside Node for Windows compatibility

### DIFF
--- a/catalog/workflow.yaml
+++ b/catalog/workflow.yaml
@@ -8,6 +8,6 @@ nodes:
     type: automatic
     steps:
       - name: "Move shared dependencies to pnpm-workspace.yaml catalog"
-        run: node "$CODEMOD_PATH/dist/index.js"
+        run: node -e "import(require('url').pathToFileURL(process.env.CODEMOD_PATH+'/dist/index.js').href)"
       - name: "Install"
         run: pnpm install

--- a/v11/workflow.yaml
+++ b/v11/workflow.yaml
@@ -8,4 +8,4 @@ nodes:
     type: automatic
     steps:
       - name: "Run pnpm v10 → v11 migration"
-        run: node "$CODEMOD_PATH/dist/index.js"
+        run: node -e "import(require('url').pathToFileURL(process.env.CODEMOD_PATH+'/dist/index.js').href)"


### PR DESCRIPTION
## Summary
- The `run` step used `$CODEMOD_PATH` for env var expansion, which works under `sh -c` (Linux/macOS) but not under `cmd /C` (Windows). Node received a literal `"$CODEMOD_PATH/dist/index.js"` and failed with `MODULE_NOT_FOUND`.
- Read the env var inside Node via `process.env.CODEMOD_PATH` and use `url.pathToFileURL` so dynamic `import()` works with absolute Windows paths too.
- Same fix applied to `catalog/workflow.yaml`, which had the identical pattern.

Closes #14

## Test plan
- [x] YAML still parses and the `run` field round-trips intact
- [x] End-to-end: ran the v11 migration against a sample project via `sh -c` using the new command — package.json bumped to pnpm@11 and pnpm-workspace.yaml written
- [x] `pnpm test` in `v11/` — 39/39 passing
- [ ] Confirm on Windows with `pnpm dlx codemod run pnpm-v10-to-v11`