### PR TITLE
fix: target pnpm@11.0.1 and preserve single-quote style in pnpm-workspace.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
 
   v11:
     dependencies:
+      '@pnpm/yaml.document-sync':
+        specifier: ^1100.0.0
+        version: 1100.0.0
       glob:
         specifier: ^10.4.1
         version: 10.4.5
@@ -61,8 +64,8 @@ importers:
         specifier: ^7.6.2
         version: 7.6.2
       yaml:
-        specifier: ^2.4.5
-        version: 2.4.5
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@types/node':
         specifier: 20.9.0
@@ -104,24 +107,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.8.3':
     resolution: {integrity: sha512-fed2ji8s+I/m8upWpTJGanqiJ0rnlHOK3DdxsyVLZQ8ClY6qLuPc9uehCREBifRJLl/iJyQpHIRufLDeotsPtw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.8.3':
     resolution: {integrity: sha512-UHrGJX7PrKMKzPGoEsooKC9jXJMa28TUSMjcIlbDnIO4EAavCoVmNQaIuUSH0Ls2mpGMwUIf+aZJv657zfWWjA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.8.3':
     resolution: {integrity: sha512-I8G2QmuE1teISyT8ie1HXsjFRz9L1m5n83U1O6m30Kw+kPMPSKjag6QGUn+sXT8V+XWIZxFFBoTDEDZW2KPDDw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.8.3':
     resolution: {integrity: sha512-J+Hu9WvrBevfy06eU1Na0lpc7uR9tibm9maHynLIoAjLZpQU3IW+OKHUtyL8p6/3pT2Ju5t5emReeIS2SAxhkQ==}
@@ -452,6 +459,10 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@pnpm/yaml.document-sync@1100.0.0':
+    resolution: {integrity: sha512-pT+pFPM9r7bFVNbY4OU31H5vDYOzGrLgSVFfPexwo7aOZe8Tt5FELkiegAUIECrfL1oyRd0rGNZy4zagHuWSdg==}
+    engines: {node: '>=22.13'}
+
   '@types/node@20.9.0':
     resolution: {integrity: sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==}
 
@@ -630,6 +641,11 @@ packages:
   yaml@2.4.5:
     resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
     engines: {node: '>= 14'}
+    hasBin: true
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
 snapshots:
@@ -835,6 +851,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@pnpm/yaml.document-sync@1100.0.0':
+    dependencies:
+      yaml: 2.8.3
 
   '@types/node@20.9.0':
     dependencies:
@@ -1043,3 +1063,5 @@ snapshots:
       strip-ansi: 7.1.0
 
   yaml@2.4.5: {}
+
+  yaml@2.8.3: {}

--- a/v11/README.md
+++ b/v11/README.md
@@ -68,7 +68,7 @@ The `ignoreDepScripts` setting has no equivalent — the codemod removes it and 
 
 ### Bumps the `packageManager` field in `package.json`
 
-If the root `package.json` pins pnpm below v11 via `packageManager`, it is bumped to `pnpm@11.0.1`.
+If the root `package.json` pins pnpm below v11 via `packageManager`, it is bumped to the latest pnpm v11 release. The exact version is resolved at runtime from the `latest-11` dist-tag on the npm registry. If the registry is unreachable, the codemod falls back to a pinned version (currently `pnpm@11.0.1`).
 
 ## Things the codemod will NOT do automatically
 

--- a/v11/README.md
+++ b/v11/README.md
@@ -68,7 +68,7 @@ The `ignoreDepScripts` setting has no equivalent — the codemod removes it and 
 
 ### Bumps the `packageManager` field in `package.json`
 
-If the root `package.json` pins pnpm below v11 via `packageManager`, it is bumped to `pnpm@11.0.0-rc.5`.
+If the root `package.json` pins pnpm below v11 via `packageManager`, it is bumped to `pnpm@11.0.1`.
 
 ## Things the codemod will NOT do automatically
 

--- a/v11/package.json
+++ b/v11/package.json
@@ -3,9 +3,10 @@
 	"private": true,
 	"license": "MIT",
 	"dependencies": {
+		"@pnpm/yaml.document-sync": "^1100.0.0",
 		"glob": "^10.4.1",
 		"semver": "^7.6.2",
-		"yaml": "^2.4.5"
+		"yaml": "^2.8.3"
 	},
 	"devDependencies": {
 		"@types/node": "20.9.0",
@@ -14,7 +15,12 @@
 		"tsx": "^4.19.0",
 		"typescript": "^5.2.2"
 	},
-	"files": ["README.md", "codemod.yaml", "workflow.yaml", "/dist/index.js"],
+	"files": [
+		"README.md",
+		"codemod.yaml",
+		"workflow.yaml",
+		"/dist/index.js"
+	],
 	"type": "module",
 	"scripts": {
 		"build": "esbuild src/cli.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --banner:js=\"import{createRequire as __cr}from 'node:module';const require=__cr(import.meta.url);\"",

--- a/v11/src/cli.ts
+++ b/v11/src/cli.ts
@@ -1,3 +1,6 @@
 import { runMigration } from "./index.js";
 
-runMigration();
+runMigration().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/v11/src/index.ts
+++ b/v11/src/index.ts
@@ -13,7 +13,26 @@ import {
 import { parseNpmrc, serializeNpmrc } from "./npmrc.js";
 import { hasOwn, isSafeKey } from "./safe-keys.js";
 
-const PNPM_V11_VERSION = "11.0.1";
+// Used when the npm registry can't be reached (offline, private mirror, etc.).
+// Bump alongside each pnpm v11 release.
+const PNPM_V11_FALLBACK_VERSION = "11.0.1";
+const REGISTRY_DIST_TAGS_URL =
+	"https://registry.npmjs.org/-/package/pnpm/dist-tags";
+const REGISTRY_TIMEOUT_MS = 5000;
+
+const resolveLatestPnpmV11 = async (): Promise<string | null> => {
+	try {
+		const response = await fetch(REGISTRY_DIST_TAGS_URL, {
+			signal: AbortSignal.timeout(REGISTRY_TIMEOUT_MS),
+		});
+		if (!response.ok) return null;
+		const distTags = (await response.json()) as Record<string, unknown>;
+		const latest11 = distTags["latest-11"];
+		return typeof latest11 === "string" ? latest11 : null;
+	} catch {
+		return null;
+	}
+};
 
 type PackageJson = {
 	name?: string;
@@ -72,14 +91,17 @@ const readYamlDocument = (
 	}
 };
 
-const bumpPackageManager = (packageManager: string): string | null => {
+const bumpPackageManager = (
+	packageManager: string,
+	targetVersion: string,
+): string | null => {
 	const match = /^pnpm@(.+)$/.exec(packageManager);
 	if (!match) return null;
 	const current = match[1] as string;
 	const coerced = semver.coerce(current);
 	if (!coerced) return null;
 	if (semver.gte(coerced, "11.0.0")) return null;
-	return `pnpm@${PNPM_V11_VERSION}`;
+	return `pnpm@${targetVersion}`;
 };
 
 // Returns true if the `.npmrc` file was actually changed on disk.
@@ -149,7 +171,16 @@ export type MigrationRun = {
 	mutatedSubprojectNpmrcs: number;
 };
 
-export const runMigration = (cwd: string = process.cwd()): MigrationRun => {
+export type RunMigrationOptions = {
+	// Skip the npm-registry lookup for the latest pnpm v11 release. Useful for
+	// tests and offline runs.
+	pnpmVersion?: string;
+};
+
+export const runMigration = async (
+	cwd: string = process.cwd(),
+	options: RunMigrationOptions = {},
+): Promise<MigrationRun> => {
 	const packageJsonPath = resolve(cwd, "package.json");
 	const workspaceYamlPath = resolve(cwd, "pnpm-workspace.yaml");
 	const npmrcPath = resolve(cwd, ".npmrc");
@@ -269,7 +300,14 @@ export const runMigration = (cwd: string = process.cwd()): MigrationRun => {
 		mutatedPackageJson = true;
 	}
 	if (nextPackageJson.packageManager) {
-		const bumped = bumpPackageManager(nextPackageJson.packageManager);
+		const targetVersion =
+			options.pnpmVersion ??
+			(await resolveLatestPnpmV11()) ??
+			PNPM_V11_FALLBACK_VERSION;
+		const bumped = bumpPackageManager(
+			nextPackageJson.packageManager,
+			targetVersion,
+		);
 		if (bumped) {
 			nextPackageJson.packageManager = bumped;
 			mutatedPackageJson = true;

--- a/v11/src/index.ts
+++ b/v11/src/index.ts
@@ -12,7 +12,7 @@ import {
 import { parseNpmrc, serializeNpmrc } from "./npmrc.js";
 import { hasOwn, isSafeKey } from "./safe-keys.js";
 
-const PNPM_V11_VERSION = "11.0.0-rc.5";
+const PNPM_V11_VERSION = "11.0.1";
 
 type PackageJson = {
 	name?: string;
@@ -241,7 +241,7 @@ export const runMigration = (cwd: string = process.cwd()): MigrationRun => {
 		const originalYaml = workspaceYamlExists
 			? readFileSync(workspaceYamlPath, "utf8")
 			: "";
-		const nextYaml = YAML.stringify(next);
+		const nextYaml = YAML.stringify(next, { singleQuote: true });
 		if (nextYaml !== originalYaml) {
 			writeFileSync(workspaceYamlPath, nextYaml);
 			mutatedWorkspaceYaml = true;

--- a/v11/src/index.ts
+++ b/v11/src/index.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { patchDocument } from "@pnpm/yaml.document-sync";
 import { globSync } from "glob";
 import * as semver from "semver";
 import * as YAML from "yaml";
@@ -58,10 +59,14 @@ const writeJson = (path: string, value: unknown): void => {
 	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 };
 
-const readYaml = <T>(path: string): T | null => {
+const readYamlDocument = (
+	path: string,
+): { document: YAML.Document; data: Record<string, unknown> } | null => {
 	try {
-		const parsed = YAML.parse(readFileSync(path, "utf8"));
-		return (parsed ?? null) as T | null;
+		const document = YAML.parseDocument(readFileSync(path, "utf8"));
+		if (document.errors.length > 0) return null;
+		const data = (document.toJSON() ?? {}) as Record<string, unknown>;
+		return { document, data };
 	} catch {
 		return null;
 	}
@@ -170,9 +175,12 @@ export const runMigration = (cwd: string = process.cwd()): MigrationRun => {
 		Object.keys(pnpmSettingsFromPackageJson).length > 0;
 
 	const workspaceYamlExists = existsSync(workspaceYamlPath);
-	const existingWorkspaceYaml = workspaceYamlExists
-		? readYaml<Record<string, unknown>>(workspaceYamlPath) ?? {}
-		: {};
+	const workspaceYamlParsed = workspaceYamlExists
+		? readYamlDocument(workspaceYamlPath)
+		: null;
+	const workspaceDocument =
+		workspaceYamlParsed?.document ?? new YAML.Document();
+	const existingWorkspaceYaml = workspaceYamlParsed?.data ?? {};
 	const workspacePackages = Array.isArray(existingWorkspaceYaml.packages)
 		? (existingWorkspaceYaml.packages as string[])
 		: [];
@@ -241,7 +249,11 @@ export const runMigration = (cwd: string = process.cwd()): MigrationRun => {
 		const originalYaml = workspaceYamlExists
 			? readFileSync(workspaceYamlPath, "utf8")
 			: "";
-		const nextYaml = YAML.stringify(next, { singleQuote: true });
+		patchDocument(workspaceDocument, next);
+		const nextYaml = workspaceDocument.toString({
+			singleQuote: true,
+			lineWidth: 0,
+		});
 		if (nextYaml !== originalYaml) {
 			writeFileSync(workspaceYamlPath, nextYaml);
 			mutatedWorkspaceYaml = true;

--- a/v11/test/run-migration.test.ts
+++ b/v11/test/run-migration.test.ts
@@ -162,6 +162,37 @@ describe("runMigration — end-to-end", () => {
 		}
 	});
 
+	test("preserves comments in pnpm-workspace.yaml", () => {
+		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
+		try {
+			writeFileSync(
+				join(root, "package.json"),
+				JSON.stringify({
+					name: "root",
+					pnpm: { onlyBuiltDependencies: ["electron"] },
+				}),
+			);
+			writeFileSync(
+				join(root, "pnpm-workspace.yaml"),
+				[
+					"# top-of-file comment",
+					"packages:",
+					"  # only the apps directory for now",
+					"  - apps/*",
+					"",
+				].join("\n"),
+			);
+
+			runMigration(root);
+
+			const yaml = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
+			assert.match(yaml, /# top-of-file comment/);
+			assert.match(yaml, /# only the apps directory for now/);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	test("leaves pinned v11 packageManager alone", () => {
 		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
 		try {

--- a/v11/test/run-migration.test.ts
+++ b/v11/test/run-migration.test.ts
@@ -71,10 +71,10 @@ const setupWorkspace = () => {
 };
 
 describe("runMigration — end-to-end", () => {
-	test("performs the full workspace migration", () => {
+	test("performs the full workspace migration", async () => {
 		const root = setupWorkspace();
 		try {
-			const result = runMigration(root);
+			const result = await runMigration(root, { pnpmVersion: "11.0.1" });
 
 			const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
 			assert.equal(pkg.packageManager, "pnpm@11.0.1");
@@ -122,10 +122,10 @@ describe("runMigration — end-to-end", () => {
 		}
 	});
 
-	test("is a no-op when there is no package.json", () => {
+	test("is a no-op when there is no package.json", async () => {
 		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
 		try {
-			const result = runMigration(root);
+			const result = await runMigration(root, { pnpmVersion: "11.0.1" });
 			assert.equal(result.mutatedPackageJson, false);
 			assert.equal(result.mutatedWorkspaceYaml, false);
 		} finally {
@@ -133,7 +133,7 @@ describe("runMigration — end-to-end", () => {
 		}
 	});
 
-	test("uses single quotes when stringifying pnpm-workspace.yaml", () => {
+	test("uses single quotes when stringifying pnpm-workspace.yaml", async () => {
 		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
 		try {
 			writeFileSync(
@@ -150,7 +150,7 @@ describe("runMigration — end-to-end", () => {
 				"packages:\n  - '*'\n  - '!excluded/*'\n",
 			);
 
-			runMigration(root);
+			await runMigration(root, { pnpmVersion: "11.0.1" });
 
 			const yaml = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
 			assert.match(yaml, /'\*'/);
@@ -162,7 +162,7 @@ describe("runMigration — end-to-end", () => {
 		}
 	});
 
-	test("preserves comments in pnpm-workspace.yaml", () => {
+	test("preserves comments in pnpm-workspace.yaml", async () => {
 		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
 		try {
 			writeFileSync(
@@ -183,7 +183,7 @@ describe("runMigration — end-to-end", () => {
 				].join("\n"),
 			);
 
-			runMigration(root);
+			await runMigration(root, { pnpmVersion: "11.0.1" });
 
 			const yaml = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
 			assert.match(yaml, /# top-of-file comment/);
@@ -193,7 +193,7 @@ describe("runMigration — end-to-end", () => {
 		}
 	});
 
-	test("leaves pinned v11 packageManager alone", () => {
+	test("leaves pinned v11 packageManager alone", async () => {
 		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
 		try {
 			writeFileSync(
@@ -203,10 +203,59 @@ describe("runMigration — end-to-end", () => {
 					packageManager: "pnpm@11.0.1",
 				}),
 			);
-			runMigration(root);
+			await runMigration(root, { pnpmVersion: "11.0.1" });
 			const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
 			assert.equal(pkg.packageManager, "pnpm@11.0.1");
 		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("resolves the latest pnpm v11 from the npm registry by default", async () => {
+		const originalFetch = globalThis.fetch;
+		const calls: string[] = [];
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			calls.push(typeof input === "string" ? input : input.toString());
+			return new Response(JSON.stringify({ "latest-11": "11.99.0" }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
+		try {
+			writeFileSync(
+				join(root, "package.json"),
+				JSON.stringify({ name: "root", packageManager: "pnpm@10.5.0" }),
+			);
+			await runMigration(root);
+			const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+			assert.equal(pkg.packageManager, "pnpm@11.99.0");
+			assert.equal(calls.length, 1);
+			assert.match(calls[0] ?? "", /registry\.npmjs\.org.*pnpm\/dist-tags/);
+		} finally {
+			globalThis.fetch = originalFetch;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("falls back to the pinned version when the registry fetch fails", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => {
+			throw new Error("network unreachable");
+		}) as typeof fetch;
+
+		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
+		try {
+			writeFileSync(
+				join(root, "package.json"),
+				JSON.stringify({ name: "root", packageManager: "pnpm@10.5.0" }),
+			);
+			await runMigration(root);
+			const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+			assert.match(pkg.packageManager, /^pnpm@11\./);
+		} finally {
+			globalThis.fetch = originalFetch;
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/v11/test/run-migration.test.ts
+++ b/v11/test/run-migration.test.ts
@@ -77,7 +77,7 @@ describe("runMigration — end-to-end", () => {
 			const result = runMigration(root);
 
 			const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
-			assert.equal(pkg.packageManager, "pnpm@11.0.0-rc.5");
+			assert.equal(pkg.packageManager, "pnpm@11.0.1");
 			assert.ok(!("pnpm" in pkg), "pnpm field should be removed");
 			assert.deepEqual(pkg.devEngines.runtime, {
 				name: "node",
@@ -133,6 +133,35 @@ describe("runMigration — end-to-end", () => {
 		}
 	});
 
+	test("uses single quotes when stringifying pnpm-workspace.yaml", () => {
+		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
+		try {
+			writeFileSync(
+				join(root, "package.json"),
+				JSON.stringify({
+					name: "root",
+					pnpm: { onlyBuiltDependencies: ["electron"] },
+				}),
+			);
+			// `*` and `!…/*` must be quoted in YAML; previously the codemod emitted
+			// double quotes, overriding the user's single-quote style.
+			writeFileSync(
+				join(root, "pnpm-workspace.yaml"),
+				"packages:\n  - '*'\n  - '!excluded/*'\n",
+			);
+
+			runMigration(root);
+
+			const yaml = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
+			assert.match(yaml, /'\*'/);
+			assert.match(yaml, /'!excluded\/\*'/);
+			assert.doesNotMatch(yaml, /"\*"/);
+			assert.doesNotMatch(yaml, /"!excluded\/\*"/);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	test("leaves pinned v11 packageManager alone", () => {
 		const root = mkdtempSync(join(tmpdir(), "pnpm-codemod-v11-e2e-"));
 		try {
@@ -140,12 +169,12 @@ describe("runMigration — end-to-end", () => {
 				join(root, "package.json"),
 				JSON.stringify({
 					name: "already-v11",
-					packageManager: "pnpm@11.0.0-rc.5",
+					packageManager: "pnpm@11.0.1",
 				}),
 			);
 			runMigration(root);
 			const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
-			assert.equal(pkg.packageManager, "pnpm@11.0.0-rc.5");
+			assert.equal(pkg.packageManager, "pnpm@11.0.1");
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary
- Bump the v11 codemod's target version from `11.0.0-rc.5` (an RC) to `11.0.1`, the latest stable v11 on npm
- Pass `{ singleQuote: true }` to `YAML.stringify` so values that must be quoted (e.g. `'*'`, `'!excluded/*'`) keep single quotes instead of getting flipped to double quotes
- Add a regression test covering the single-quote preservation behavior; update existing tests and README to reference `pnpm@11.0.1`

Reported by a user trying the migration: "that sets the version to the latest RC and changed all my single quotes to double quotes in the workspace.yaml."

## Test plan
- [x] `pnpm test` (40/40 pass, including the new single-quote test)
- [x] `pnpm typecheck`
- [x] `pnpm build`